### PR TITLE
Swagger 호환성 문제

### DIFF
--- a/src/main/java/com/zkdlu/apiresponsespringbootstarter/core/advice/ResponseAdvice.java
+++ b/src/main/java/com/zkdlu/apiresponsespringbootstarter/core/advice/ResponseAdvice.java
@@ -7,13 +7,26 @@ import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.PathContainer;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import java.util.Arrays;
+import java.util.List;
 
 @RestControllerAdvice
 public class ResponseAdvice implements ResponseBodyAdvice<Object> {
+    private final List<PathPattern> whitelist = Arrays.asList(
+            new PathPatternParser().parse("/v*/api-docs"),
+            new PathPatternParser().parse("/swagger-resources/**"),
+            new PathPatternParser().parse("/swagger-ui.html"),
+            new PathPatternParser().parse("/webjars/**"),
+            new PathPatternParser().parse("/swagger/**"));
+
     private final ResponseService responseService;
     private final ResponseProperties responseProperties;
 
@@ -29,6 +42,7 @@ public class ResponseAdvice implements ResponseBodyAdvice<Object> {
 
     @Override
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        if (whitelist.stream().anyMatch(pathPattern -> pathPattern.matches(PathContainer.parsePath(request.getURI().getPath())))) return body;
         if (body instanceof CommonResult) {
             CommonResult commonResult = (CommonResult) body;
             try {


### PR DESCRIPTION
해당 프로젝트와 Swagger를 연동하여 사용하려는 중 오류사항이 있어서 요청합니다.
swagger-ui를 사용 시 swagger 구성요소들이 ResponseAdvice로 핸들링되어 Swagger가 정상동작하지 않아 해결안을 요청합니다.  

![image](https://user-images.githubusercontent.com/22608825/169929907-ffee7ce1-c203-4e15-bc20-867af8f1b02c.png)


- properties로 제외하여 설정해도 좋을 것 같습니다.